### PR TITLE
Fix string createdAt and add userId

### DIFF
--- a/importer.js
+++ b/importer.js
@@ -110,7 +110,7 @@ const importNotes = async (connection, id) => {
 			.orderBy('id', 'DESC')
 			.andWhere(lastId ? 'id < :id' : 'true')
 			.setParameter('id', lastId)
-			.select(['id', 'base36_decode(substring(id, 1, 8))+946684800000 AS "createdAt"', '"userHost"', '"channelId"', 'cw', 'text', 'tags'])
+			.select(['id', 'base36_decode(substring(id, 1, 8))+946684800000 AS "createdAt"', '"userHost"', '"channelId"', 'cw', 'text', 'tags', '"userId"'])
 			.take(options.batchSize)
 			.getRawMany();
 


### PR DESCRIPTION
- `createdAt` の値が string で typeorm から返ってくることがあり、そのためにインデックスが壊れることがあったため、parseIntするようにしました
- `userId` がインデックスに最近追加されたため、これを追加しました